### PR TITLE
Update to fretboards 0.4.0 and reuse fretboard instance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5746,9 +5746,9 @@
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "fretboards": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/fretboards/-/fretboards-0.2.5.tgz",
-      "integrity": "sha512-IFVGvvGUrnuFrTBwMSATov0GRxJ7r2AxseLixCT960a/MrWcBhTAWCuIxcjCZsC85Fov2B0LZaNdihTHzdx03g==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/fretboards/-/fretboards-0.4.0.tgz",
+      "integrity": "sha512-Grfzg6+mEHL2fx/Ui8g8I3GvjkM6RlWkDJd8itKH+phcLMOM/zgqq/CrX1owNLpjp93oSl+DpMwSO749YgpZBQ==",
       "requires": {
         "d3-selection": "^1.4.1"
       }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@testing-library/user-event": "^7.2.1",
     "bootstrap": "^4.1.2",
     "faker": "^4.1.0",
-    "fretboards": "^0.2.5",
+    "fretboards": "^0.4.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-inlinesvg": "^1.2.0",


### PR DESCRIPTION
I've updated to the latest version of fretboards (0.4.0) to take advantage of the API improvements (this game is a useful validation that the API makes sense): now the fretboard instance only needs to be created once, and can be updated dynamically.

I've had to split the fretboard generation from the random note generation to make that possible.